### PR TITLE
fix(openai): transform non-streaming tool_calls to Anthropic tool_use format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ once_cell = "1"            # Lazy statics
 async-trait = "0.1"        # Async trait support
 dirs = "5"                 # User directories
 regex = "1"                # Regular expressions
+uuid = { version = "1.0", features = ["v4", "serde"] }  # UUID generation for streaming
 
 # OAuth & Auth
 oauth2 = "4"               # OAuth 2.0 client


### PR DESCRIPTION
The transform_response function was only extracting text content and ignoring tool_calls from OpenAI responses. This caused tool calling to fail silently.

Now properly transforms OpenAI tool_calls format:
- OpenAI: message.tool_calls[].function.{name, arguments}
- Anthropic: content[].tool_use.{id, name, input}

Streaming already had this transformation, now non-streaming matches.