### PR TITLE
fix: SSE streaming bugs causing event drops and malformed responses

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -7,6 +7,7 @@ use crate::router::Router;
 use crate::providers::ProviderRegistry;
 use crate::auth::TokenStore;
 use axum::{
+    body::Body,
     extract::State,
     http::{HeaderMap, StatusCode},
     response::{
@@ -18,7 +19,7 @@ use axum::{
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tracing::{error, info};
-use futures::stream::StreamExt;
+use futures::stream::{StreamExt, TryStreamExt};
 
 /// Application state shared across handlers
 #[derive(Clone)]
@@ -704,20 +705,24 @@ async fn handle_messages(
                         Ok(stream) => {
                             info!("✅ Streaming request started with provider: {}", mapping.provider);
 
-                            // Convert byte stream to SSE response
-                            // The provider returns raw bytes (SSE format), we pass them through
-                            let sse_stream = stream.map(|result| {
-                                result.map(|bytes| {
-                                    // Convert bytes to string for SSE event
-                                    let data = String::from_utf8_lossy(&bytes).to_string();
-                                    Event::default().data(data)
-                                }).map_err(|e| {
-                                    error!("Stream error: {}", e);
-                                    std::io::Error::new(std::io::ErrorKind::Other, e.to_string())
-                                })
+                            // Convert provider stream to HTTP response
+                            // The provider already returns properly formatted SSE bytes (event: + data: lines)
+                            // We pass them through as-is without wrapping
+                            let body_stream = stream.map_err(|e| {
+                                error!("Stream error: {}", e);
+                                std::io::Error::new(std::io::ErrorKind::Other, e.to_string())
                             });
 
-                            return Ok(Sse::new(sse_stream).into_response());
+                            let body = Body::from_stream(body_stream);
+                            let response = Response::builder()
+                                .status(200)
+                                .header("Content-Type", "text/event-stream")
+                                .header("Cache-Control", "no-cache")
+                                .header("Connection", "keep-alive")
+                                .body(body)
+                                .unwrap();
+
+                            return Ok(response);
                         }
                         Err(e) => {
                             info!("⚠️ Provider {} streaming failed: {}, trying next fallback", mapping.provider, e);


### PR DESCRIPTION
This fixes two bugs in SSE (Server-Sent Events) streaming that caused streaming responses to fail or malfunction:

## Bug 1: SseStream drops events when multiple arrive in same TCP chunk

**Problem:**
When multiple SSE events arrived in a single TCP chunk, only the first event was emitted and all others were discarded. This happened because parse_sse_events() returned all events, but we only took .first() and then cleared the entire buffer.

**Example:**
  Chunk contains: event: start\ndata: {...}\n\nevent: delta\ndata: {...}\n\n
  Old behavior: Emit 'start', discard 'delta'
  New behavior: Emit both 'start' and 'delta' in sequence

**Fix:**
- Added event_queue: VecDeque<SseEvent> to buffer parsed events
- Changed buffer management to preserve incomplete events
- Events are queued and emitted one-by-one across multiple poll_next() calls

This was particularly problematic for tool_calls in OpenAI-compatible providers, where the tool_call chunk and finish_reason chunk often arrived together.

## Bug 2: Server double-wraps SSE events causing malformed output

**Problem:**
The server was wrapping provider SSE events (which already have 'event:' and 'data:' lines) with axum's Event::default().data(), producing invalid SSE:

  Provider returns:  event: message_start\ndata: {...}\n\n
  Server wrapped as: data: event: message_start\ndata: data: {...}\ndata: \n\n

This caused SSE parsers in clients (like Zed) to fail with deserialization errors.

**Fix:**
- Removed Event::default().data() wrapper
- Changed from Sse::new() helper to raw HTTP response with Body::from_stream()
- Now passes through provider's properly-formatted SSE bytes unchanged

## Impact

These fixes enable reliable SSE streaming for:
- Anthropic Messages API streaming responses
- OpenAI-compatible provider streaming (Cerebras, Groq, etc.)
- Tool call streaming with proper finish_reason handling
- Multi-event SSE responses from any provider