### PR TITLE
Fix OpenAI Streaming and Tool Calling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ once_cell = "1"            # Lazy statics
 async-trait = "0.1"        # Async trait support
 dirs = "5"                 # User directories
 regex = "1"                # Regular expressions
+uuid = { version = "1.0", features = ["v4", "serde"] }  # UUID generation for streaming
 
 # OAuth & Auth
 oauth2 = "4"               # OAuth 2.0 client

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -1015,10 +1015,9 @@ impl OpenAIProvider {
                 .or(choice.delta.reasoning.as_ref()); // Support reasoning field for GLM/Cerebras
 
             if let Some(text) = text_content {
-                // Skip empty text
-                if text.is_empty() {
-                    continue;
-                }
+                // Don't use continue for empty text - finish_reason processing
+                // is required even when content is empty to ensure proper stream termination.
+                if !text.is_empty() {
 
                 // Emit content_block_start if this is the first text content
                 if !state.text_block_open {
@@ -1045,6 +1044,7 @@ impl OpenAIProvider {
                     }
                 });
                 output.push_str(&format!("event: content_block_delta\ndata: {}\n\n", delta));
+                }
             }
 
             // Tool Calls Transformation (OpenAI function calling → Anthropic tool_use)
@@ -1542,7 +1542,7 @@ impl AnthropicProvider for OpenAIProvider {
                                 );
 
                                 if !sse_output.is_empty() {
-                                    tracing::debug!("📤 Sending {} bytes:\n{}", sse_output.len(), sse_output);
+                                    tracing::debug!("SSE: {} bytes", sse_output.len());
                                 }
 
                                 // Return as raw bytes (already SSE-formatted)

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -7,6 +7,7 @@ use crate::router::Router;
 use crate::providers::ProviderRegistry;
 use crate::auth::TokenStore;
 use axum::{
+    body::Body,
     extract::State,
     http::{HeaderMap, StatusCode},
     response::{
@@ -18,7 +19,7 @@ use axum::{
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tracing::{error, info};
-use futures::stream::StreamExt;
+use futures::stream::TryStreamExt;
 
 /// Application state shared across handlers
 #[derive(Clone)]
@@ -704,20 +705,24 @@ async fn handle_messages(
                         Ok(stream) => {
                             info!("✅ Streaming request started with provider: {}", mapping.provider);
 
-                            // Convert byte stream to SSE response
-                            // The provider returns raw bytes (SSE format), we pass them through
-                            let sse_stream = stream.map(|result| {
-                                result.map(|bytes| {
-                                    // Convert bytes to string for SSE event
-                                    let data = String::from_utf8_lossy(&bytes).to_string();
-                                    Event::default().data(data)
-                                }).map_err(|e| {
-                                    error!("Stream error: {}", e);
-                                    std::io::Error::new(std::io::ErrorKind::Other, e.to_string())
-                                })
+                            // Convert provider stream to HTTP response
+                            // The provider already returns properly formatted SSE bytes (event: + data: lines)
+                            // We pass them through as-is without wrapping
+                            let body_stream = stream.map_err(|e| {
+                                error!("Stream error: {}", e);
+                                std::io::Error::new(std::io::ErrorKind::Other, e.to_string())
                             });
 
-                            return Ok(Sse::new(sse_stream).into_response());
+                            let body = Body::from_stream(body_stream);
+                            let response = Response::builder()
+                                .status(200)
+                                .header("Content-Type", "text/event-stream")
+                                .header("Cache-Control", "no-cache")
+                                .header("Connection", "keep-alive")
+                                .body(body)
+                                .unwrap();
+
+                            return Ok(response);
                         }
                         Err(e) => {
                             info!("⚠️ Provider {} streaming failed: {}, trying next fallback", mapping.provider, e);


### PR DESCRIPTION
This PR fixes bugs in SSE streaming and implements full tool calling support for OpenAI-compatible providers.

  ## SSE Streaming Fixes

  Event Queue Bug (src/providers/streaming.rs)
  - Problem: Multiple SSE events in same TCP chunk → only first emitted, rest dropped
  - Impact: finish_reason chunks lost, clients hang with incomplete responses
  - Fix: Added VecDeque to buffer and emit all parsed events

  Double SSE Wrapping (src/server/mod.rs)
  - Problem: Server wrapped provider SSE with Event::default().data() → malformed output
  - Fix: Pass through raw SSE bytes using Body::from_stream()

  ## Tool Calling Support

  Request Transformation
  - Emit tool messages before user content (OpenAI requires: assistant → tool → user)
  - Fixes 422 error with parallel tool calls

  Response Transformation
  - Non-streaming: Transform message.tool_calls[] → content[].tool_use
  - Streaming: Handle incremental tool calls across multiple chunks using StreamTransformState
  - Map finish_reason correctly: "tool_calls" → "tool_use"